### PR TITLE
Remove conflict with web server when issuing certificate

### DIFF
--- a/ssl.config
+++ b/ssl.config
@@ -60,7 +60,7 @@ container_commands:
     command: "mkdir -p /opt/certbot && wget https://dl.eff.org/certbot-auto -O /opt/certbot/certbot-auto && chmod a+x /opt/certbot/certbot-auto"
   # issue the certificate if it does not exist. Remove --staging to deploy in production.
   20_install_certificate:
-    command: "sudo /opt/certbot/certbot-auto certonly --debug --non-interactive --email ${LETSENCRYPT_EMAIL} --agree-tos --standalone --domains ${LETSENCRYPT_DOMAIN} --keep-until-expiring --staging"
+    command: "sudo /opt/certbot/certbot-auto certonly --debug --non-interactive --email ${LETSENCRYPT_EMAIL} --agree-tos --standalone --domains ${LETSENCRYPT_DOMAIN} --keep-until-expiring --pre-hook \"service httpd stop\" --staging"
   # create a link so we can use '/etc/letsencrypt/live/ebcert/fullchain.pem'
   # in the apache config file
   30_link:


### PR DESCRIPTION
Add "--pre-hook" flag to the "install_certificate" script to stop the httpd service and prevent conflict on port 80.